### PR TITLE
Fix string join on list of integers

### DIFF
--- a/geopackage_validator/validations/srs_check.py
+++ b/geopackage_validator/validations/srs_check.py
@@ -83,6 +83,6 @@ class SrsEqualValidator(validator.Validator):
         assert srs_list is not None
         srs_set = set(srs_list)
         if len(srs_set) > 1:
-            return [self.message.format(srs=", ".join(srs_set))]
+            return [self.message.format(srs=", ".join([str(x) for x in srs_set]))]
 
         return []


### PR DESCRIPTION
Kleine bugfix, liep tegen de volgende fout aan:

```
{
    "geopackage_validator_version": "0.5.1",
    "start_time": "2021-02-24T13:58:45.254174",
    "duration_seconds": 81,
    "geopackage": "/home/anton/workspace/geopackage-validator/.vscode/NL.IMRO.0000.BZKmrGCRarro-5040.gpkg",
    "success": false,
    "validations_executed": [],
    "results": [
        {
            "validation_code": "ERROR",
            "validation_description": "No unexpected errors must occur.",
            "level": "unknown_error",
            "locations": [
                "Traceback (most recent call last):",
                "  File \"/home/anton/workspace/geopackage-validator/geopackage_validator/validate.py\", line 89, in validate\n    result = validator(dataset, table_definitions=table_definitions).validate()",
                "  File \"/home/anton/workspace/geopackage-validator/geopackage_validator/validations/validator.py\", line 63, in validate\n    results = list(self.check())",
                "  File \"/home/anton/workspace/geopackage-validator/geopackage_validator/validations/srs_check.py\", line 80, in check\n    return self.check_srs_equal(srs_list)",
                "  File \"/home/anton/workspace/geopackage-validator/geopackage_validator/validations/srs_check.py\", line 86, in check_srs_equal\n    return [self.message.format(srs=\", \".join(srs_set))]",
                "TypeError: sequence item 0: expected str instance, int found"
            ]
        }
    ]
}
```

Je mag geen String.join aanroepen op een list van integers, dat moet eerst een lijst van strings zijn kennelijk.