### PR TITLE
Improve gdal error handling.

### DIFF
--- a/geopackage_validator/validate.py
+++ b/geopackage_validator/validate.py
@@ -60,12 +60,22 @@ def validate(
 
     # Register GDAL error handler function
     def gdal_error_handler(err_class, err_num, error):
-        trace = [error.replace("\n", " ")]
+        trace = error.replace("\n", " ")
         gdal_traces.append(trace)
 
     dataset = utils.open_dataset(gpkg_path, gdal_error_handler)
-    initial_gdal_traces = [gdal_traces.pop() for _ in range(len(gdal_traces))]
-    initial_gdal_errors = format_gdal_errors(initial_gdal_traces)
+    if len(gdal_traces):
+        initial_gdal_traces = [gdal_traces.pop() for _ in range(len(gdal_traces))]
+        initial_gdal_errors = [
+            format_result(
+                validation_code="GDAL_ERROR",
+                validation_description="No unexpected GDAL errors must occur.",
+                level=ValidationLevel.UNKNOWN,
+                trace=initial_gdal_traces,
+            )
+        ]
+    else:
+        initial_gdal_errors = []
 
     if dataset is None:
         return initial_gdal_errors, None, False
@@ -78,14 +88,16 @@ def validate(
     validators = validators_to_use(validations, validations_path, is_rq8_requested)
 
     validation_results = []
-    success = True
+    success = not initial_gdal_errors
 
     for validator in validators:
+        validation_error = False
         try:
             result = validator(dataset, table_definitions=table_definitions).validate()
 
             if result is not None:
                 validation_results.append(result)
+                validation_error = True
                 success = success and validator.level == ValidationLevel.RECCOMENDATION
         except Exception:
             exc_type, exc_value, exc_traceback = sys.exc_info()
@@ -100,39 +112,27 @@ def validate(
                 trace=trace,
             )
             validation_results.append(output)
+            validation_error = True
             success = False
         current_gdal_traces = [gdal_traces.pop() for _ in range(len(gdal_traces))]
         if current_gdal_traces:
             success = False
-            for trace in current_gdal_traces:
+            if validation_error:
+                validation_results[-1]["locations"].extend(current_gdal_traces)
+            else:
                 output = format_result(
                     validation_code=validator.validation_code,
                     validation_description=f"No unexpected errors must occur for: {validator.__doc__}",
                     level=validator.level,
-                    trace=trace,
+                    trace=current_gdal_traces,
                 )
                 validation_results.append(output)
-
-    # results has values when a gdal error is thrown:
-    success = success and not initial_gdal_traces
 
     return (
         initial_gdal_errors + validation_results,
         get_validation_codes(validators),
         success,
     )
-
-
-def format_gdal_errors(traces):
-    return [
-        format_result(
-            validation_code="GDAL_ERROR",
-            validation_description="No unexpected GDAL errors must occur.",
-            level=ValidationLevel.UNKNOWN,
-            trace=trace,
-        )
-        for trace in traces
-    ]
 
 
 def get_validation_descriptions():

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -109,6 +109,7 @@ def test_validate_all_validations_with_broken_gpkg_throws_gdal_error():
         gpkg_path="tests/data/test_broken_geopackage.gpkg", validations="ALL"
     )
     assert len(results) == 1
+    print(results)
     assert results[0]["locations"] == [
         "At least one of the required GeoPackage tables, gpkg_spatial_ref_sys or gpkg_contents, is missing"
     ]


### PR DESCRIPTION
 When gdal errors are thrown within the scope of a valildation, their trace is added to the validation error of that validation result. 

Example of gdal error logging: 

```json
{
    "geopackage_validator_version": "0.6.2",
    "start_time": "2021-07-21T13:51:41.693279",
    "duration_seconds": 0,
    "geopackage": "/home/bergr/data/vivet.gpkg",
    "success": false,
    "validations_executed": [
        "RQ1",
        "RQ2",
        "RQ4",
        "RQ5",
        "RQ6",
        "RQ7",
        "RQ9",
        "RQ10",
        "RQ11",
        "RQ12",
        "RQ13",
        "RQ14",
        "RQ15",
        "RC1",
        "RC2",
        "RC3",
        "RC4"
    ],
    "results": [
        {
            "validation_code": "RQ1",
            "validation_description": "Layer names must start with a letter, and valid characters are lowercase a-z, numbers or underscores.",
            "level": "error",
            "locations": [
                "Error layer: Vivet punt",
                "Error layer: Vivet Voronoi Vivet"
            ]
        },
        {
            "validation_code": "RQ2",
            "validation_description": "No unexpected errors must occur for: Layers must have at least one feature.",
            "level": "error",
            "locations": [
                "Traceback (most recent call last):",
                "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validate.py\", line 96, in validate\n    result = validator(dataset, table_definitions=table_definitions).validate()",
                "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/validator.py\", line 63, in validate\n    results = list(self.check())",
                "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 29, in check\n    return self.check_contains_features(counts)",
                "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 34, in check_contains_features\n    return [",
                "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 34, in <listcomp>\n    return [",
                "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 13, in query_layerfeature_counts\n    (table_count,) = table_featurecount.GetNextFeature()",
                "AttributeError: 'NoneType' object has no attribute 'GetNextFeature'",
                "In ExecuteSQL(): sqlite3_prepare_v2(SELECT count(*) from Vivet punt):   no such table: Vivet"
            ]
        },
        {
            "validation_code": "RQ11",
            "validation_description": "No unexpected errors must occur for: OGR indexed feature counts must be up to date",
            "level": "error",
            "locations": [
                "Traceback (most recent call last):",
                "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validate.py\", line 96, in validate\n    result = validator(dataset, table_definitions=table_definitions).validate()",
                "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/validator.py\", line 63, in validate\n    results = list(self.check())",
                "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 48, in check\n    return self.layerfeature_check_ogr_index(counts)",
                "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 54, in layerfeature_check_ogr_index\n    return [",
                "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 54, in <listcomp>\n    return [",
                "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 13, in query_layerfeature_counts\n    (table_count,) = table_featurecount.GetNextFeature()",
                "AttributeError: 'NoneType' object has no attribute 'GetNextFeature'",
                "In ExecuteSQL(): sqlite3_prepare_v2(SELECT count(*) from Vivet punt):   no such table: Vivet"
            ]
        },
        {
            "validation_code": "RQ15",
            "validation_description": "No unexpected errors must occur for: All table geometries types must match the geometry_type_name from the gpkg_geometry_columns table.",
            "level": "error",
            "locations": [
                "In ExecuteSQL(): sqlite3_prepare_v2(SELECT     CASE ST_AsText(geom)         WHEN 'GEOMETRYCOLLECTION()'             THEN 'GEOMETRYCOLLECTION'         ELSE ST_GEOMETRYTYPE(geom)     END AS geom_type     , count(geom) AS count     , cast(rowid AS INTEGER) AS row_id FROM Vivet Voronoi Vivet WHERE geom_type != 'POLYGON' GROUP BY geom_type):   near \"Vivet\": syntax error",
                "In ExecuteSQL(): sqlite3_prepare_v2(SELECT     CASE ST_AsText(geom)         WHEN 'GEOMETRYCOLLECTION()'             THEN 'GEOMETRYCOLLECTION'         ELSE ST_GEOMETRYTYPE(geom)     END AS geom_type     , count(geom) AS count     , cast(rowid AS INTEGER) AS row_id FROM Vivet punt WHERE geom_type != 'POINT' GROUP BY geom_type):   no such table: Vivet"
            ]
        },
        {
            "validation_code": "RC3",
            "validation_description": "No unexpected errors must occur for: It is recommended to only use multidimensional geometry coordinates (elevation and measurement) when necessary.",
            "level": "recommendation",
            "locations": [
                "In ExecuteSQL(): sqlite3_prepare_v2( SELECT DISTINCT     (ST_MinZ(geom) == 0 AND ST_MaxZ(geom) == 0) as z_check,     (ST_MinM(geom) IS NOT NULL AND      ST_MinM(geom) == 0 AND ST_MaxM(geom) == 0) as m_check,      st_ndims(geom) as ndims FROM Vivet Voronoi Vivet where st_ndims(geom) > 2; ):   near \"Vivet\": syntax error",
                "In ExecuteSQL(): sqlite3_prepare_v2( SELECT DISTINCT     (ST_MinZ(geom) == 0 AND ST_MaxZ(geom) == 0) as z_check,     (ST_MinM(geom) IS NOT NULL AND      ST_MinM(geom) == 0 AND ST_MaxM(geom) == 0) as m_check,      st_ndims(geom) as ndims FROM Vivet punt where st_ndims(geom) > 2; ):   no such table: Vivet"
            ]
        },
        {
            "validation_code": "RC4",
            "validation_description": "No unexpected errors must occur for: It is recommended that all (MULTI)POLYGON geometries have a counter-clockwise orientation for their exterior ring, and a clockwise direction for all interior rings.",
            "level": "recommendation",
            "locations": [
                "In ExecuteSQL(): sqlite3_prepare_v2(SELECT cast(rowid AS INTEGER) AS row_id, count(geom) as amount FROM Vivet Voronoi Vivet WHERE NOT ST_IsPolygonCCW(geom)):   near \"Vivet\": syntax error"
            ]
        }
    ]
}
```

compared before: 
```json
{
    "geopackage_validator_version": "0.6.2",
    "start_time": "2021-07-21T13:58:38.417721",
    "duration_seconds": 0,
    "geopackage": "/home/bergr/data/vivet.gpkg",
    "success": false,
    "validations_executed": [
        "RQ1",
        "RQ2",
        "RQ4",
        "RQ5",
        "RQ6",
        "RQ7",
        "RQ9",
        "RQ10",
        "RQ11",
        "RQ12",
        "RQ13",
        "RQ14",
        "RQ15",
        "RC1",
        "RC2",
        "RC3",
        "RC4"
    ],
    "results": [
        {
            "validation_code": "GDAL_ERROR",
            "validation_description": "No unexpected GDAL errors must occur.",
            "level": "unknown_error",
            "locations": [
                "In ExecuteSQL(): sqlite3_prepare_v2(SELECT count(*) from Vivet punt):   no such table: Vivet"
            ]
        },
        {
            "validation_code": "GDAL_ERROR",
            "validation_description": "No unexpected GDAL errors must occur.",
            "level": "unknown_error",
            "locations": [
                "In ExecuteSQL(): sqlite3_prepare_v2(SELECT count(*) from Vivet punt):   no such table: Vivet"
            ]
        },
        {
            "validation_code": "GDAL_ERROR",
            "validation_description": "No unexpected GDAL errors must occur.",
            "level": "unknown_error",
            "locations": [
                "In ExecuteSQL(): sqlite3_prepare_v2(SELECT     CASE ST_AsText(geom)         WHEN 'GEOMETRYCOLLECTION()'             THEN 'GEOMETRYCOLLECTION'         ELSE ST_GEOMETRYTYPE(geom)     END AS geom_type     , count(geom) AS count     , cast(rowid AS INTEGER) AS row_id FROM Vivet punt WHERE geom_type != 'POINT' GROUP BY geom_type):   no such table: Vivet"
            ]
        },
        {
            "validation_code": "GDAL_ERROR",
            "validation_description": "No unexpected GDAL errors must occur.",
            "level": "unknown_error",
            "locations": [
                "In ExecuteSQL(): sqlite3_prepare_v2(SELECT     CASE ST_AsText(geom)         WHEN 'GEOMETRYCOLLECTION()'             THEN 'GEOMETRYCOLLECTION'         ELSE ST_GEOMETRYTYPE(geom)     END AS geom_type     , count(geom) AS count     , cast(rowid AS INTEGER) AS row_id FROM Vivet Voronoi Vivet WHERE geom_type != 'POLYGON' GROUP BY geom_type):   near \"Vivet\": syntax error"
            ]
        },
        {
            "validation_code": "GDAL_ERROR",
            "validation_description": "No unexpected GDAL errors must occur.",
            "level": "unknown_error",
            "locations": [
                "In ExecuteSQL(): sqlite3_prepare_v2( SELECT DISTINCT     (ST_MinZ(geom) == 0 AND ST_MaxZ(geom) == 0) as z_check,     (ST_MinM(geom) IS NOT NULL AND      ST_MinM(geom) == 0 AND ST_MaxM(geom) == 0) as m_check,      st_ndims(geom) as ndims FROM Vivet punt where st_ndims(geom) > 2; ):   no such table: Vivet"
            ]
        },
        {
            "validation_code": "GDAL_ERROR",
            "validation_description": "No unexpected GDAL errors must occur.",
            "level": "unknown_error",
            "locations": [
                "In ExecuteSQL(): sqlite3_prepare_v2( SELECT DISTINCT     (ST_MinZ(geom) == 0 AND ST_MaxZ(geom) == 0) as z_check,     (ST_MinM(geom) IS NOT NULL AND      ST_MinM(geom) == 0 AND ST_MaxM(geom) == 0) as m_check,      st_ndims(geom) as ndims FROM Vivet Voronoi Vivet where st_ndims(geom) > 2; ):   near \"Vivet\": syntax error"
            ]
        },
        {
            "validation_code": "GDAL_ERROR",
            "validation_description": "No unexpected GDAL errors must occur.",
            "level": "unknown_error",
            "locations": [
                "In ExecuteSQL(): sqlite3_prepare_v2(SELECT cast(rowid AS INTEGER) AS row_id, count(geom) as amount FROM Vivet Voronoi Vivet WHERE NOT ST_IsPolygonCCW(geom)):   near \"Vivet\": syntax error"
            ]
        },
        {
            "validation_code": "RQ1",
            "validation_description": "Layer names must start with a letter, and valid characters are lowercase a-z, numbers or underscores.",
            "level": "error",
            "locations": [
                "Error layer: Vivet punt",
                "Error layer: Vivet Voronoi Vivet"
            ]
        },
        [
            {
                "validation_code": "RQ2",
                "validation_description": "No unexpected errors must occur for: Layers must have at least one feature.",
                "level": "error",
                "locations": [
                    "Traceback (most recent call last):",
                    "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validate.py\", line 88, in validate\n    result = validator(dataset, table_definitions=table_definitions).validate()",
                    "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/validator.py\", line 63, in validate\n    results = list(self.check())",
                    "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 29, in check\n    return self.check_contains_features(counts)",
                    "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 34, in check_contains_features\n    return [",
                    "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 34, in <listcomp>\n    return [",
                    "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 13, in query_layerfeature_counts\n    (table_count,) = table_featurecount.GetNextFeature()",
                    "AttributeError: 'NoneType' object has no attribute 'GetNextFeature'"
                ]
            }
        ],
        [
            {
                "validation_code": "RQ11",
                "validation_description": "No unexpected errors must occur for: OGR indexed feature counts must be up to date",
                "level": "error",
                "locations": [
                    "Traceback (most recent call last):",
                    "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validate.py\", line 88, in validate\n    result = validator(dataset, table_definitions=table_definitions).validate()",
                    "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/validator.py\", line 63, in validate\n    results = list(self.check())",
                    "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 48, in check\n    return self.layerfeature_check_ogr_index(counts)",
                    "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 54, in layerfeature_check_ogr_index\n    return [",
                    "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 54, in <listcomp>\n    return [",
                    "  File \"/home/bergr/dev/geopackage-validator/geopackage_validator/validations/layerfeature_check.py\", line 13, in query_layerfeature_counts\n    (table_count,) = table_featurecount.GetNextFeature()",
                    "AttributeError: 'NoneType' object has no attribute 'GetNextFeature'"
                ]
            }
        ]
    ]
}
```
