### PR TITLE
Proposed fix for dealing with gdal warnings.

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -22,7 +22,7 @@ ARG gid=1000
 RUN groupadd -g $gid pdok && useradd -lm -u $uid -g $gid pdok
 
 RUN pip3 install --upgrade --no-cache-dir setuptools pip
-RUN pip3 install --no-cache-dir pipenv
+RUN pip3 install --no-cache-dir virtualenv==v20.7.2 pipenv
 
 ADD local_entrypoint.sh /entry/local_entrypoint.sh
 ENV PATH /home/pdok/.local/bin:$PATH

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The current checks are (see also the 'show-validations' command):
 
 | Validation code | Description                                                                                                                                                                                         |
 |:---------------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|   GDAL_ERROR    | No unexpected GDAL errors must occur.                                                                                                                                                               |
 |       RQ0       | _LEGACY:_ * Geopackage must conform to table names in the given JSON or YAML definitions.                                                                                                           |
 |       RQ1       | Layer names must start with a letter, and valid characters are lowercase a-z, numbers or underscores.                                                                                               |
 |       RQ2       | Layers must have at least one feature.                                                                                                                                                              |
@@ -46,7 +47,7 @@ The current checks are (see also the 'show-validations' command):
 |       RC2       | It is recommended to give all GEOMETRY type columns the same name.                                                                                                                                  |
 |       RC3       | It is recommended to only use multidimensional geometry coordinates (elevation and measurement) when necessary.                                                                                     |
 |       RC4       | It is recommended that all (MULTI)POLYGON geometries have a counter-clockwise orientation for their exterior ring, and a clockwise direction for all interior rings.                                |
-|       RC5       | It is recommended that gdal Warnings that occur while validating the geopackage are looked into.                                                                                                    |
+|  GDAL_WARNINGS  | It is recommended that gdal warnings are looked into.                                                                                                                                               |
 
 \* Legacy requirements are only executed with the validate command when explicitly requested in the validation set.  
 

--- a/README.md
+++ b/README.md
@@ -24,30 +24,30 @@
 The Geopackage validator can validate .gkpg files to see if they conform to a set of standards.
 The current checks are (see also the 'show-validations' command):
 
-| Validation code | Description                                                                                                                                                                                         |
-|:---------------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|   GDAL_ERROR    | No unexpected GDAL errors must occur.                                                                                                                                                               |
-|       RQ0       | _LEGACY:_ * Geopackage must conform to table names in the given JSON or YAML definitions.                                                                                                           |
-|       RQ1       | Layer names must start with a letter, and valid characters are lowercase a-z, numbers or underscores.                                                                                               |
-|       RQ2       | Layers must have at least one feature.                                                                                                                                                              |
-|       RQ3       | _LEGACY:_ * Layer features should have an allowed geometry_type (one of POINT, LINESTRING, POLYGON, MULTIPOINT, MULTILINESTRING, or MULTIPOLYGON).                                                  |
-|       RQ4       | The geopackage should have no views defined.                                                                                                                                                        |
-|       RQ5       | Geometry should be valid.                                                                                                                                                                           |
-|       RQ6       | Column names must start with a letter, and valid characters are lowercase a-z, numbers or underscores.                                                                                              |
-|       RQ7       | Tables should have a feature id column with unique index.                                                                                                                                           |
-|       RQ8       | Geopackage must conform to given JSON or YAML definitions.                                                                                                                                          |
-|       RQ9       | All geometry tables must have an rtree index.                                                                                                                                                       |
-|      RQ10       | All geometry table rtree indexes must be valid.                                                                                                                                                     |
-|      RQ11       | OGR indexed feature counts must be up to date.                                                                                                                                                      |
-|      RQ12       | Only the following EPSG spatial reference systems are allowed: 28992, 3034, 3035, 3038, 3039, 3040, 3041, 3042, 3043, 3044, 3045, 3046, 3047, 3048, 3049, 3050, 3051, 4258, 4936, 4937, 5730, 7409. |
-|      RQ13       | It is required to give all GEOMETRY features the same default spatial reference system.                                                                                                             |
-|      RQ14       | The geometry_type_name from the gpkg_geometry_columns table must be one of POINT, LINESTRING, POLYGON, MULTIPOINT, MULTILINESTRING, or MULTIPOLYGON.                                                |
-|      RQ15       | All table geometries must match the geometry_type_name from the gpkg_geometry_columns table.                                                                                                        |
-|       RC1       | It is recommended to name all GEOMETRY type columns 'geom'.                                                                                                                                         |
-|       RC2       | It is recommended to give all GEOMETRY type columns the same name.                                                                                                                                  |
-|       RC3       | It is recommended to only use multidimensional geometry coordinates (elevation and measurement) when necessary.                                                                                     |
-|       RC4       | It is recommended that all (MULTI)POLYGON geometries have a counter-clockwise orientation for their exterior ring, and a clockwise direction for all interior rings.                                |
-|  GDAL_WARNINGS  | It is recommended that gdal warnings are looked into.                                                                                                                                               |
+| Validation code  | Description                                                                                                                                                                                         |
+|:----------------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|  UNKNOWN_ERROR   | No unexpected (GDAL) errors must occur.                                                                                                                                                             |
+|       RQ0        | _LEGACY:_ * Geopackage must conform to table names in the given JSON or YAML definitions.                                                                                                           |
+|       RQ1        | Layer names must start with a letter, and valid characters are lowercase a-z, numbers or underscores.                                                                                               |
+|       RQ2        | Layers must have at least one feature.                                                                                                                                                              |
+|       RQ3        | _LEGACY:_ * Layer features should have an allowed geometry_type (one of POINT, LINESTRING, POLYGON, MULTIPOINT, MULTILINESTRING, or MULTIPOLYGON).                                                  |
+|       RQ4        | The geopackage should have no views defined.                                                                                                                                                        |
+|       RQ5        | Geometry should be valid.                                                                                                                                                                           |
+|       RQ6        | Column names must start with a letter, and valid characters are lowercase a-z, numbers or underscores.                                                                                              |
+|       RQ7        | Tables should have a feature id column with unique index.                                                                                                                                           |
+|       RQ8        | Geopackage must conform to given JSON or YAML definitions.                                                                                                                                          |
+|       RQ9        | All geometry tables must have an rtree index.                                                                                                                                                       |
+|       RQ10       | All geometry table rtree indexes must be valid.                                                                                                                                                     |
+|       RQ11       | OGR indexed feature counts must be up to date.                                                                                                                                                      |
+|       RQ12       | Only the following EPSG spatial reference systems are allowed: 28992, 3034, 3035, 3038, 3039, 3040, 3041, 3042, 3043, 3044, 3045, 3046, 3047, 3048, 3049, 3050, 3051, 4258, 4936, 4937, 5730, 7409. |
+|       RQ13       | It is required to give all GEOMETRY features the same default spatial reference system.                                                                                                             |
+|       RQ14       | The geometry_type_name from the gpkg_geometry_columns table must be one of POINT, LINESTRING, POLYGON, MULTIPOINT, MULTILINESTRING, or MULTIPOLYGON.                                                |
+|       RQ15       | All table geometries must match the geometry_type_name from the gpkg_geometry_columns table.                                                                                                        |
+|       RC1        | It is recommended to name all GEOMETRY type columns 'geom'.                                                                                                                                         |
+|       RC2        | It is recommended to give all GEOMETRY type columns the same name.                                                                                                                                  |
+|       RC3        | It is recommended to only use multidimensional geometry coordinates (elevation and measurement) when necessary.                                                                                     |
+|       RC4        | It is recommended that all (MULTI)POLYGON geometries have a counter-clockwise orientation for their exterior ring, and a clockwise direction for all interior rings.                                |
+| UNKNOWN_WARNINGS | It is recommended that the unexpected (GDAL) warnings are looked into.                                                                                                                              |
 
 \* Legacy requirements are only executed with the validate command when explicitly requested in the validation set.  
 

--- a/README.md
+++ b/README.md
@@ -24,28 +24,29 @@
 The Geopackage validator can validate .gkpg files to see if they conform to a set of standards.
 The current checks are (see also the 'show-validations' command):
 
-| Validation code | Description                                                  |
-| :-------------: | ------------------------------------------------------------ |
-|       RQ0       | _LEGACY:_ * Geopackage must conform to table names in the given JSON or YAML definitions. |
-|       RQ1       | Layer names must start with a letter, and valid characters are lowercase a-z, numbers or underscores. |
-|       RQ2       | Layers must have at least one feature.                       |
-|       RQ3       | _LEGACY:_ * Layer features should have an allowed geometry_type (one of POINT, LINESTRING, POLYGON, MULTIPOINT, MULTILINESTRING, or MULTIPOLYGON). |
-|       RQ4       | The geopackage should have no views defined.                 |
-|       RQ5       | Geometry should be valid.                                    |
-|       RQ6       | Column names must start with a letter, and valid characters are lowercase a-z, numbers or underscores. |
-|       RQ7       | Tables should have a feature id column with unique index.    |
-|       RQ8       | Geopackage must conform to given JSON or YAML definitions.           |
-|       RQ9       | All geometry tables must have an rtree index.                |
-|       RQ10      | All geometry table rtree indexes must be valid.              |
-|       RQ11      | OGR indexed feature counts must be up to date.               |
-|       RQ12      | Only the following EPSG spatial reference systems are allowed: 28992, 3034, 3035, 3038, 3039, 3040, 3041, 3042, 3043, 3044, 3045, 3046, 3047, 3048, 3049, 3050, 3051, 4258, 4936, 4937, 5730, 7409. |
-|       RQ13      | It is required to give all GEOMETRY features the same default spatial reference system. |
-|       RQ14      | The geometry_type_name from the gpkg_geometry_columns table must be one of POINT, LINESTRING, POLYGON, MULTIPOINT, MULTILINESTRING, or MULTIPOLYGON. |
-|       RQ15      | All table geometries must match the geometry_type_name from the gpkg_geometry_columns table. |
-|       RC1       | It is recommended to name all GEOMETRY type columns 'geom'.  |
-|       RC2       | It is recommended to give all GEOMETRY type columns the same name. |
-|       RC3       | It is recommended to only use multidimensional geometry coordinates (elevation and measurement) when necessary. |
-|       RC4       | It is recommended that all (MULTI)POLYGON geometries have a counter-clockwise orientation for their exterior ring, and a clockwise direction for all interior rings. |
+| Validation code | Description                                                                                                                                                                                         |
+|:---------------:|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|       RQ0       | _LEGACY:_ * Geopackage must conform to table names in the given JSON or YAML definitions.                                                                                                           |
+|       RQ1       | Layer names must start with a letter, and valid characters are lowercase a-z, numbers or underscores.                                                                                               |
+|       RQ2       | Layers must have at least one feature.                                                                                                                                                              |
+|       RQ3       | _LEGACY:_ * Layer features should have an allowed geometry_type (one of POINT, LINESTRING, POLYGON, MULTIPOINT, MULTILINESTRING, or MULTIPOLYGON).                                                  |
+|       RQ4       | The geopackage should have no views defined.                                                                                                                                                        |
+|       RQ5       | Geometry should be valid.                                                                                                                                                                           |
+|       RQ6       | Column names must start with a letter, and valid characters are lowercase a-z, numbers or underscores.                                                                                              |
+|       RQ7       | Tables should have a feature id column with unique index.                                                                                                                                           |
+|       RQ8       | Geopackage must conform to given JSON or YAML definitions.                                                                                                                                          |
+|       RQ9       | All geometry tables must have an rtree index.                                                                                                                                                       |
+|      RQ10       | All geometry table rtree indexes must be valid.                                                                                                                                                     |
+|      RQ11       | OGR indexed feature counts must be up to date.                                                                                                                                                      |
+|      RQ12       | Only the following EPSG spatial reference systems are allowed: 28992, 3034, 3035, 3038, 3039, 3040, 3041, 3042, 3043, 3044, 3045, 3046, 3047, 3048, 3049, 3050, 3051, 4258, 4936, 4937, 5730, 7409. |
+|      RQ13       | It is required to give all GEOMETRY features the same default spatial reference system.                                                                                                             |
+|      RQ14       | The geometry_type_name from the gpkg_geometry_columns table must be one of POINT, LINESTRING, POLYGON, MULTIPOINT, MULTILINESTRING, or MULTIPOLYGON.                                                |
+|      RQ15       | All table geometries must match the geometry_type_name from the gpkg_geometry_columns table.                                                                                                        |
+|       RC1       | It is recommended to name all GEOMETRY type columns 'geom'.                                                                                                                                         |
+|       RC2       | It is recommended to give all GEOMETRY type columns the same name.                                                                                                                                  |
+|       RC3       | It is recommended to only use multidimensional geometry coordinates (elevation and measurement) when necessary.                                                                                     |
+|       RC4       | It is recommended that all (MULTI)POLYGON geometries have a counter-clockwise orientation for their exterior ring, and a clockwise direction for all interior rings.                                |
+|       RC5       | It is recommended that gdal Warnings that occur while validating the geopackage are looked into.                                                                                                    |
 
 \* Legacy requirements are only executed with the validate command when explicitly requested in the validation set.  
 

--- a/geopackage_validator/constants.py
+++ b/geopackage_validator/constants.py
@@ -1,6 +1,6 @@
 import re
 
-__version__ = "0.6.5"
+__version__ = "0.6.6"
 
 ALLOWED_PROJECTIONS_LIST = [
     28992,

--- a/geopackage_validator/validate.py
+++ b/geopackage_validator/validate.py
@@ -66,7 +66,7 @@ def validate(
         trace = error.replace("\n", " ")
         # import pdb
         # pdb.set_trace()
-        if err_class >= gdal.CE_Warning:
+        if err_class == gdal.CE_Warning:
             gdal_warning_traces.append(trace)
         else:
             gdal_error_traces.append(trace)

--- a/geopackage_validator/validate.py
+++ b/geopackage_validator/validate.py
@@ -3,6 +3,8 @@ import logging
 import sys
 import traceback
 
+from osgeo import gdal
+
 from geopackage_validator.generate import TableDefinition
 from geopackage_validator import validations as validation
 from geopackage_validator.validations.validator import (
@@ -62,10 +64,12 @@ def validate(
     # Register GDAL error handler function
     def gdal_error_handler(err_class, err_num, error):
         trace = error.replace("\n", " ")
-        if "Warning" in error and not "Error" in error:
+        # import pdb
+        # pdb.set_trace()
+        if err_class >= gdal.CE_Warning:
             gdal_warning_traces.append(trace)
-            return
-        gdal_error_traces.append(trace)
+        else:
+            gdal_error_traces.append(trace)
 
     dataset = utils.open_dataset(gpkg_path, gdal_error_handler)
     if len(gdal_error_traces):
@@ -147,9 +151,9 @@ def validate(
 
     if gdal_warning_traces:
         output = format_result(
-            validation_code="RC5",
-            validation_description=f"It is recommended that gdal Warnings that occur while validating the geopackage are looked into.",
-            level=ValidationLevel.RC,
+            validation_code="GDAL_WARNINGS",
+            validation_description="It is recommended that these gdal warnings are looked into.",
+            level=ValidationLevel.UNKNOWN,
             trace=gdal_warning_traces,
         )
         validation_results.append(output)

--- a/geopackage_validator/validate.py
+++ b/geopackage_validator/validate.py
@@ -80,7 +80,7 @@ def validate(
             format_result(
                 validation_code="GDAL_ERROR",
                 validation_description="No unexpected GDAL errors must occur.",
-                level=ValidationLevel.UNKNOWN,
+                level=ValidationLevel.UNKNOWN_ERROR,
                 trace=initial_gdal_traces,
             )
         ]
@@ -94,7 +94,7 @@ def validate(
                     format_result(
                         validation_code="GDAL_ERROR",
                         validation_description="Could not open gpkg.",
-                        level=ValidationLevel.UNKNOWN,
+                        level=ValidationLevel.UNKNOWN_ERROR,
                         trace=[],
                     )
                 ],
@@ -157,7 +157,7 @@ def validate(
         output = format_result(
             validation_code="GDAL_WARNINGS",
             validation_description="It is recommended that these gdal warnings are looked into.",
-            level=ValidationLevel.UNKNOWN,
+            level=ValidationLevel.UNKNOWN_WARNING,
             trace=gdal_warning_traces,
         )
         validation_results.append(output)

--- a/geopackage_validator/validate.py
+++ b/geopackage_validator/validate.py
@@ -78,9 +78,9 @@ def validate(
         ]
         initial_gdal_errors = [
             format_result(
-                validation_code="GDAL_ERROR",
-                validation_description="No unexpected GDAL errors must occur.",
-                level=ValidationLevel.UNKNOWN_ERROR,
+                validation_code="UNKNOWN_ERROR",
+                validation_description="No unexpected (GDAL) errors must occur.",
+                level=ValidationLevel.ERROR,
                 trace=initial_gdal_traces,
             )
         ]
@@ -155,9 +155,9 @@ def validate(
 
     if gdal_warning_traces:
         output = format_result(
-            validation_code="GDAL_WARNINGS",
-            validation_description="It is recommended that these gdal warnings are looked into.",
-            level=ValidationLevel.UNKNOWN_WARNING,
+            validation_code="UNKNOWN_WARNINGS",
+            validation_description="It is recommended that these unexpected (GDAL) warnings are looked into.",
+            level=ValidationLevel.RECCOMENDATION,
             trace=gdal_warning_traces,
         )
         validation_results.append(output)

--- a/geopackage_validator/validate.py
+++ b/geopackage_validator/validate.py
@@ -73,7 +73,9 @@ def validate(
 
     dataset = utils.open_dataset(gpkg_path, gdal_error_handler)
     if len(gdal_error_traces):
-        initial_gdal_traces = [gdal_error_traces.pop() for _ in range(len(gdal_error_traces))]
+        initial_gdal_traces = [
+            gdal_error_traces.pop() for _ in range(len(gdal_error_traces))
+        ]
         initial_gdal_errors = [
             format_result(
                 validation_code="GDAL_ERROR",
@@ -135,7 +137,9 @@ def validate(
             validation_results.append(output)
             validation_error = True
             success = False
-        current_gdal_error_traces = [gdal_error_traces.pop() for _ in range(len(gdal_error_traces))]
+        current_gdal_error_traces = [
+            gdal_error_traces.pop() for _ in range(len(gdal_error_traces))
+        ]
         if current_gdal_error_traces:
             success = False
             if validation_error:

--- a/geopackage_validator/validate.py
+++ b/geopackage_validator/validate.py
@@ -80,7 +80,7 @@ def validate(
             format_result(
                 validation_code="UNKNOWN_ERROR",
                 validation_description="No unexpected (GDAL) errors must occur.",
-                level=ValidationLevel.ERROR,
+                level=ValidationLevel.UNKNOWN_ERROR,
                 trace=initial_gdal_traces,
             )
         ]
@@ -157,7 +157,7 @@ def validate(
         output = format_result(
             validation_code="UNKNOWN_WARNINGS",
             validation_description="It is recommended that these unexpected (GDAL) warnings are looked into.",
-            level=ValidationLevel.RECCOMENDATION,
+            level=ValidationLevel.UNKNOWN_WARNING,
             trace=gdal_warning_traces,
         )
         validation_results.append(output)

--- a/geopackage_validator/validate.py
+++ b/geopackage_validator/validate.py
@@ -149,7 +149,7 @@ def validate(
         output = format_result(
             validation_code="RC5",
             validation_description=f"It is recommended that gdal Warnings that occur while validating the geopackage are looked into.",
-            level=validator.level,
+            level=ValidationLevel.RC,
             trace=gdal_warning_traces,
         )
         validation_results.append(output)

--- a/geopackage_validator/validations/validator.py
+++ b/geopackage_validator/validations/validator.py
@@ -4,7 +4,8 @@ from enum import IntEnum
 
 
 class ValidationLevel(IntEnum):
-    UNKNOWN = 0
+    UNKNOWN_ERROR = 0
+    UNKNOWN_WARNING = 0
     RQ = 1
     ERROR = 1
     RC = 2
@@ -12,7 +13,8 @@ class ValidationLevel(IntEnum):
 
 
 VALIDATION_LEVELS = {
-    ValidationLevel.UNKNOWN: "unknown_error",
+    ValidationLevel.UNKNOWN_ERROR: "unknown_error",
+    ValidationLevel.UNKNOWN_WARNING: "unknown_warning",
     ValidationLevel.RQ: "error",
     ValidationLevel.RC: "recommendation",
 }

--- a/geopackage_validator/validations/validator.py
+++ b/geopackage_validator/validations/validator.py
@@ -4,8 +4,6 @@ from enum import IntEnum
 
 
 class ValidationLevel(IntEnum):
-    UNKNOWN_ERROR = 0
-    UNKNOWN_WARNING = 0
     RQ = 1
     ERROR = 1
     RC = 2
@@ -13,8 +11,6 @@ class ValidationLevel(IntEnum):
 
 
 VALIDATION_LEVELS = {
-    ValidationLevel.UNKNOWN_ERROR: "unknown_error",
-    ValidationLevel.UNKNOWN_WARNING: "unknown_warning",
     ValidationLevel.RQ: "error",
     ValidationLevel.RC: "recommendation",
 }

--- a/geopackage_validator/validations/validator.py
+++ b/geopackage_validator/validations/validator.py
@@ -4,6 +4,8 @@ from enum import IntEnum
 
 
 class ValidationLevel(IntEnum):
+    UNKNOWN_ERROR = 0
+    UNKNOWN_WARNING = 0
     RQ = 1
     ERROR = 1
     RC = 2
@@ -11,6 +13,8 @@ class ValidationLevel(IntEnum):
 
 
 VALIDATION_LEVELS = {
+    ValidationLevel.UNKNOWN_ERROR: "unknown_error",
+    ValidationLevel.UNKNOWN_WARNING: "unknown_warning",
     ValidationLevel.RQ: "error",
     ValidationLevel.RC: "recommendation",
 }


### PR DESCRIPTION
# Omschrijving

Een omschrijving van wat je hebt toegevoegd/veranderd:

Dit heb ik getest met een gpkg met een extension. 

https://dev.kadaster.nl/jira/browse/PDOK-13810

Voorbeeld resultaat: 

```json
{
    "geopackage_validator_version": "0.6.5",
    "start_time": "2022-01-06T15:53:50.816259",
    "duration_seconds": 6,
    "geopackage": "/home/bergr/data/gpkgs/brosgm.gpkg",
    "success": true,
    "validations_executed": [
        "RQ1",
        "RQ2",
        "RQ4",
        "RQ5",
        "RQ6",
        "RQ7",
        "RQ9",
        "RQ10",
        "RQ11",
        "RQ12",
        "RQ13",
        "RQ14",
        "RQ15",
        "RC1",
        "RC2",
        "RC3",
        "RC4"
    ],
    "results": [
        {
            "validation_code": "UNKNOWN_ERRORS",
            "validation_description": "No unexpected  (gdal) errors must occur.",
            "level": "unknown_error",
            "locations": [
                "Could not open geopackage."
            ]
        },
        {
            "validation_code": "UNKNOWN_WARNINGS",
            "validation_description": "It is recommended that these (gdal) warnings are looked into.",
            "level": "unknown_warning",
            "locations": [
                "Layer nga_properties relies on the 'nga_properties' (http://ngageoint.github.io/GeoPackage/docs/extensions/properties.html) extension that should be implemented in order to read it safely, but is not currently. Some data may be missing while reading that layer."
            ]
        }
    ]
}
```


## Type verandering

(Verwijder de opties die niet relevant zijn.)

- Bugfix

# Checklist:

- [X] Ik heb de code in deze PR zelf nogmaals nagekeken
- [X] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [X] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [ ] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)