### PR TITLE
gdal 3.6 in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GDAL_VERSION=3.5.0
+ARG GDAL_VERSION=3.6.2
 
 FROM osgeo/gdal:alpine-normal-${GDAL_VERSION} AS base
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,4 +1,4 @@
-ARG GDAL_VERSION=3.5.0
+ARG GDAL_VERSION=3.6.2
 
 FROM osgeo/gdal:alpine-normal-${GDAL_VERSION} AS base
 


### PR DESCRIPTION
# Description

Use gdal 3.6(.2) in docker image and add to test matrix.
Mainly to get `geos` 10.3, in which https://github.com/locationtech/jts/pull/845 was fixed.

https://dev.kadaster.nl/jira/browse/PDOK-15093

## Type of change

- Minor change (typo, formatting, version bump)
- Bugfix

# Checklist:

- [x] I took a glance at my code again
- [ ] I left the code better than how I found it
- [ ] The code is readable and has comments where necessary
- [x] I added/expanded tests where necessary
- [x] I ran the tests proving my changes
- [ ] The internal PDOK documentation was updated if necessary.
- [x] There is no sensitive information in this PR (passwords etc)